### PR TITLE
remove MAINTAINER in Dockerfile

### DIFF
--- a/WKSHP-Docker101/3-WKSHP-Using-Dockerfile.ipynb
+++ b/WKSHP-Docker101/3-WKSHP-Using-Dockerfile.ipynb
@@ -173,7 +173,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "echo 'MAINTAINER myself@mydomain.org' >> build/Dockerfile\n",
     "echo 'CMD /usr/sbin/apachectl -DFOREGROUND -k start' >> build/Dockerfile\n",
     "echo \"\"\n",
     "cat build/Dockerfile"
@@ -192,7 +191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that all the first steps are very quick. This is because Docker caches steps and will not repeat them unless the Dockerfile changes. You can modify the Dockerfile by putting the `MAINTAINER` command as the second line and re-launch the build. You'll see that, in that case, Docker invalidates its cache and restarts.\n",
+    "Notice that all the first steps are very quick. This is because Docker caches steps and will not repeat them unless the Dockerfile changes.\n",
     "\n",
     "Secondly, we modified the way our Apache Web server is started by forcing it to stay in the foreground after launch. That way Docker will continue to keep the container alive.\n",
     "Now, start a container from that image to check that the web server is indeed started."


### PR DESCRIPTION
MAINTAINER argument is deprecated.
cf.  [docker documentation](https://docs.docker.com/engine/reference/builder/#maintainer-deprecated)